### PR TITLE
Simplify getConsumerObservable

### DIFF
--- a/lobby-service/src/infrastructures/kafka/consumer.js
+++ b/lobby-service/src/infrastructures/kafka/consumer.js
@@ -50,13 +50,8 @@ const initConsumer = topics =>
 
 // getConsumerObservable :: Number -> Observable Error Consumer
 const getConsumerObservable = consumerIndex =>
-  Rx.Observable.create((obs) => {
-    const consumer = storage.consumers[consumerIndex];
-    if (consumer) {
-      obs.next(consumer);
-      obs.complete();
-    } else obs.error(new Error('Consumer not found'));
-  });
+  Rx.Observable.of(storage.consumers[consumerIndex])
+    .first(val => val != undefined);
 
 // onMessage :: Consumer -> Observable Message
 const onMessage = consumer =>


### PR DESCRIPTION
Instead of creating your own Observable using `Rx.Observable.Create` it is almost always preferred to use a less low-level creator like `Rx.Observable.of`. Combined with `.first()` to only emit non-undefined values or throw an Error if none is present.